### PR TITLE
docs: add branching strategy and polish contributor docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to TaBiThA
 
-Welcome to the **TaBiThA** monorepo! This guide explains the project's architecture, conventions, and common development workflows to help you build, test, and contribute effectively.
+Welcome to the **TaBiThA** monorepo! This guide covers architecture, conventions, and workflows to get you building, testing, and shipping.
 
 ---
 
@@ -130,13 +130,13 @@ pnpm dev:copilot
 
 ### 4. Ontology Local Permissions (first time only)
 
-`pnpm setup`'s D1 bootstrap loads schema and app data, but never seeds real user grants -- those only exist in production, so a fresh local Auth database starts with nobody authorized. After you sign in to Ontology (`http://localhost:5173`) with Google for the first time, a `401` on any `/protected` page is expected, not a bug. Fix it once with:
+`pnpm setup` loads schema and app data, but never seeds real user grants — those only exist in production, so a fresh local Auth DB starts with nobody authorized. Sign in to Ontology (`http://localhost:5173`) with Google once; a `401` on any `/protected` page is expected. Fix it with:
 
 ```bash
 pnpm db:grant your.email@example.com
 ```
 
-This grants every Ontology permission to that email in your local Auth D1 only -- it never touches production. Run it again any time you reload the database from a fresh snapshot (`pnpm db:load`/`db:load:ontology`), since that resets local grants too.
+Grants every Ontology permission to that email in your local Auth D1 only — production is untouched. Re-run after any `pnpm db:load`/`db:load:ontology`, since a fresh snapshot resets local grants too.
 
 ---
 
@@ -154,6 +154,16 @@ All contributions should adhere to the **13 TaBiThA Development Philosophies** a
   - **E2E Tests (`*.spec.ts`)**: Multi-service browser integration tests executed via Playwright.
 
 👉 **Complete Definitions & Code Examples**: See the canonical [**`AGENTS.md`**](AGENTS.md) at the repository root.
+
+---
+
+## 🌱 Branching Strategy
+
+TaBiThA follows a lightweight GitHub Flow:
+
+- 🔒 `main` is always deployable.
+- 🌿 **Regular work**: branch off `main` → make your changes → open a PR targeting `main` → review + `pnpm precommit`/CI pass → squash-merge (branch auto-deletes). Naming your branch is up to you.
+- 🚑 **Hotfixes/patches**: urgent production fixes may skip the PR and push straight to `main` — enabled by GitHub's existing admin bypass on branch protection, not a separate rule to configure. Non-admins still go through a PR.
 
 ---
 
@@ -186,7 +196,7 @@ Git diffs show *what* code changed; commit messages should explain **why** the c
 
 ### Convenient Git Commit Template (`.gitmessage`)
 
-Running `pnpm setup` automatically registers the repository's `.gitmessage` template (`git config commit.template .gitmessage`). When you run `git commit` (or commit via your IDE), your editor will open pre-populated with prompts and type reminders. Lines starting with `#` are automatically stripped out by Git.
+`pnpm setup` registers the repo's `.gitmessage` template (`git config commit.template .gitmessage`) — `git commit` then opens pre-populated with prompts and type reminders. Lines starting with `#` are stripped by Git.
 
 ### ✨ AI Commit "Easy Button" in IDE
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This repository houses all core deployable web applications, developer tools, sh
 
 ## 🚀 Applications & Dedicated Ports
 
-All applications are built with **Svelte**, **SvelteKit**, **Tailwind CSS**, and **daisyUI**, deployed as Cloudflare Workers. Each app has a dedicated, non-overlapping local port configured for seamless multi-app development.
+Built with **Svelte**, **SvelteKit**, **Tailwind CSS**, and **daisyUI**, deployed as Cloudflare Workers — each app gets a dedicated, non-overlapping port for multi-app dev.
 
 | Application | Path | Local Dev URL | Dedicated Port | Production URL | Notes |
 | --- | --- | --- | --- | --- | --- |
@@ -177,7 +177,7 @@ pnpm update:interactive
 
 ### Local CI/CD Workflow Testing (Optional)
 
-For developers developing or testing GitHub Actions workflows in `.github/workflows/` locally, you can use [`act`](https://github.com/nektos/act) to run workflows in local Docker containers:
+To test GitHub Actions workflows in `.github/workflows/` locally, use [`act`](https://github.com/nektos/act) to run them in local Docker containers:
 
 ```bash
 # Installation:

--- a/apps/copilot/README.md
+++ b/apps/copilot/README.md
@@ -5,7 +5,7 @@
 
 ---
 
-## API
+## 🔌 API
 
 ### 1. Verse Copilot Notes API
 
@@ -23,18 +23,15 @@
 
 ---
 
-## Environment Setup
+## 🔐 Environment Setup
 
-`apps/copilot/.env.local` is created by the monorepo's onboarding step (`pnpm setup`,
-from the root). Fill in the secrets that are still blank there: `API_KEY_AQUIFER`,
-`GEMINI_PRIVATE_KEY`.
+`apps/copilot/.env.local` is created by the monorepo's onboarding step (`pnpm setup`, from the root). Fill in the secrets that are still blank there: `API_KEY_AQUIFER`, `GEMINI_PRIVATE_KEY`.
 
-(If `.env.local` doesn't exist yet, or is missing a var after pulling a `.env`
-template change, run `pnpm setup:env` from the root to (re)generate it.)
+(If `.env.local` doesn't exist yet, or is missing a var after pulling a `.env` template change, run `pnpm setup:env` from the root to (re)generate it.)
 
 ---
 
-## Local Development
+## 💻 Local Development
 
 From the **monorepo root**:
 
@@ -54,6 +51,6 @@ pnpm dev
 
 ---
 
-## Testing & Verification
+## ✅ Testing & Verification
 
 For unified monorepo testing, linting, and build verification commands, see [CONTRIBUTING.md](../../CONTRIBUTING.md) or run `pnpm precommit`.

--- a/apps/editor/README.md
+++ b/apps/editor/README.md
@@ -5,7 +5,7 @@
 
 ---
 
-## API
+## 🔌 API
 
 ### 1. Grammar & Rule Checker API
 
@@ -21,7 +21,7 @@
 
 ---
 
-## Local Development
+## 💻 Local Development
 
 From the **monorepo root**:
 
@@ -41,6 +41,6 @@ pnpm dev
 
 ---
 
-## Testing & Verification
+## ✅ Testing & Verification
 
 For unified monorepo testing, linting, and build verification commands, see [CONTRIBUTING.md](../../CONTRIBUTING.md) or run `pnpm precommit`.

--- a/apps/ontology/README.md
+++ b/apps/ontology/README.md
@@ -5,7 +5,7 @@
 
 ---
 
-## API
+## 🔌 API
 
 ### 1. Concept Search API
 
@@ -35,11 +35,11 @@
 
 ---
 
-## Local Development & Setup
+## 💻 Local Development & Setup
 
 ### 1. Configure Local Auth
 
-`apps/ontology/.env.local` is created by the monorepo's onboarding step (`pnpm setup`, from the root), including a generated dev `AUTH_SECRET`. Fill in `GOOGLE_OAUTH_CLIENT_SECRET` there -- grab it from the same Google Cloud Console client as `GOOGLE_OAUTH_CLIENT_ID`. The OAuth callback redirects to `http://localhost:5173/auth/callback`.
+`apps/ontology/.env.local` is created by the monorepo's onboarding step (`pnpm setup`, from the root), including a generated dev `AUTH_SECRET`. Fill in `GOOGLE_OAUTH_CLIENT_SECRET` there — grab it from the same Google Cloud Console client as `GOOGLE_OAUTH_CLIENT_ID`. The OAuth callback redirects to `http://localhost:5173/auth/callback`.
 
 (If `.env.local` doesn't exist yet, or is missing a var after pulling a `.env` template change, run `pnpm setup:env` from the root to (re)generate it.)
 
@@ -90,6 +90,6 @@ Complex terms and simplification hints are synchronized from Google Sheets every
 
 ---
 
-## Testing & Verification
+## ✅ Testing & Verification
 
 For unified monorepo testing, linting, and build verification commands, see [CONTRIBUTING.md](../../CONTRIBUTING.md) or run `pnpm precommit`.

--- a/apps/ontology/e2e/README.md
+++ b/apps/ontology/e2e/README.md
@@ -2,26 +2,26 @@
 
 Standard Playwright specs (`pnpm test:e2e`), with one addition: `/protected/*` routes are reachable in tests without ever going through Google OAuth.
 
-## How authenticated tests work
+## 🔑 How authenticated tests work
 
 `auth.setup.ts` runs once before the suite (wired in via `playwright.config.js`'s `globalSetup`) and:
 
-1. Runs `pnpm db:grant e2e-test@tabitha.local`, giving that fixture account every Ontology permission in your local Auth D1 -- the same command described in the root `CONTRIBUTING.md`.
+1. Runs `pnpm db:grant e2e-test@tabitha.local`, giving that fixture account every Ontology permission in your local Auth D1 — the same command described in the root `CONTRIBUTING.md`.
 2. Signs an Auth.js session JWT for that email using `@auth/core/jwt`'s `encode()` and the app's own `AUTH_SECRET`, then saves it as a cookie in `e2e/.auth/user.json` (gitignored).
 
-Every test then runs with that `storageState` already applied (see `playwright.config.js`'s `use.storageState`), so `page.goto('/protected/...')` just works -- no login step needed in the test itself.
+Every test then runs with that `storageState` already applied (see `playwright.config.js`'s `use.storageState`), so `page.goto('/protected/...')` just works — no login step needed in the test itself.
 
 See [`docs/decisions/0006-e2e-auth-bypass-via-signed-session-cookie.md`](../../../docs/decisions/0006-e2e-auth-bypass-via-signed-session-cookie.md) for why this approach was chosen over automating a real Google sign-in.
 
-## Requirements
+## 📋 Requirements
 
-- `apps/ontology/.env.local` must have a real `AUTH_SECRET` (from `pnpm setup:env`) -- it has to be the *same* secret the dev server itself uses, since the signed cookie is decrypted with it.
+- `apps/ontology/.env.local` must have a real `AUTH_SECRET` (from `pnpm setup:env`) — it has to be the *same* secret the dev server itself uses, since the signed cookie is decrypted with it.
 - The local Auth D1 must exist (`pnpm db:load:ontology`), since that's what `db:grant` writes into.
 - `bun` must be on `PATH` (same requirement as `pnpm db:grant`/`db:load` generally).
 
-## Don't use `context.setOffline()` to simulate offline in this app
+## ⚠️ Don't use `context.setOffline()` to simulate offline in this app
 
-This app registers a PWA service worker (`vite-plugin-pwa`), and Playwright/Chrome's `context.setOffline(true)` interacts badly with it: confirmed directly, it stalls page reactivity entirely -- even a plain form field edit stops updating component state, unrelated to any app code. Simulate offline by failing the specific request instead:
+This app registers a PWA service worker (`vite-plugin-pwa`), and Playwright/Chrome's `context.setOffline(true)` interacts badly with it: confirmed directly, it stalls page reactivity entirely — even a plain form field edit stops updating component state, unrelated to any app code. Simulate offline by failing the specific request instead:
 
 ```ts
 await page.route('**/protected/concept/update/submit', route => route.abort('internetdisconnected'))
@@ -29,8 +29,8 @@ await page.route('**/protected/concept/update/submit', route => route.abort('int
 
 See `e2e/offline_queue.spec.ts` for a full example.
 
-## If a protected-route test starts failing with a 401/redirect-to-login
+## 🧯 If a protected-route test starts failing with a 401/redirect-to-login
 
 - Confirm `AUTH_SECRET` in `.env.local` actually matches what the running dev server loaded (a stale copy from a different environment won't decrypt).
-- Confirm this app is still on the JWT session strategy with no custom `jwt`/`session` callbacks in `hooks.server.ts` -- if either changes, `auth.setup.ts`'s token shape (or the cookie-signing approach entirely) needs to be revisited; see ADR 0006's consequences.
-- Re-run `pnpm db:grant e2e-test@tabitha.local` by hand and check its output -- if the local Auth D1 was just reloaded from a snapshot, grants reset with it.
+- Confirm this app is still on the JWT session strategy with no custom `jwt`/`session` callbacks in `hooks.server.ts` — if either changes, `auth.setup.ts`'s token shape (or the cookie-signing approach entirely) needs to be revisited; see ADR 0006's consequences.
+- Re-run `pnpm db:grant e2e-test@tabitha.local` by hand and check its output — if the local Auth D1 was just reloaded from a snapshot, grants reset with it.

--- a/apps/sources/README.md
+++ b/apps/sources/README.md
@@ -5,7 +5,7 @@
 
 ---
 
-## API
+## 🔌 API
 
 ### 1. Hierarchical Navigation APIs
 
@@ -38,7 +38,7 @@
 
 ---
 
-## Local Development
+## 💻 Local Development
 
 From the **monorepo root**:
 
@@ -58,6 +58,6 @@ pnpm dev
 
 ---
 
-## Testing & Verification
+## ✅ Testing & Verification
 
 For unified monorepo testing, linting, and build verification commands, see [CONTRIBUTING.md](../../CONTRIBUTING.md) or run `pnpm precommit`.

--- a/apps/targets/README.md
+++ b/apps/targets/README.md
@@ -5,7 +5,7 @@
 
 ---
 
-## API
+## 🔌 API
 
 ### 1. Hierarchical Navigation APIs
 
@@ -33,7 +33,7 @@
 
 ---
 
-## Local Development
+## 💻 Local Development
 
 From the **monorepo root**:
 
@@ -53,6 +53,6 @@ pnpm dev
 
 ---
 
-## Testing & Verification
+## ✅ Testing & Verification
 
 For unified monorepo testing, linting, and build verification commands, see [CONTRIBUTING.md](../../CONTRIBUTING.md) or run `pnpm precommit`.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,12 +1,12 @@
-# Architecture Decision Records
+# 🗂️ Architecture Decision Records
 
 This folder captures notable architecture and process decisions made in the TaBiThA monorepo — the trade-offs considered and why we landed where we did, so the reasoning survives past the conversation (or PR) that produced it.
 
-## When to add one
+## 🤔 When to add one
 
 An entry generally makes sense when the "why" isn't obvious from the code alone: choosing between two viable approaches, deferring a capability on purpose, or a convention that a future contributor might otherwise second-guess or accidentally reverse.
 
-## Format
+## 📐 Format
 
 Each entry is `NNNN-short-title.md`, numbered sequentially in the order it was written (not necessarily chronological — older decisions can be backfilled). Entries should generally include:
 

--- a/packages/vite-config/README.md
+++ b/packages/vite-config/README.md
@@ -4,7 +4,7 @@ Shared Vite, Playwright, and SvelteKit configuration helpers for Tabitha applica
 
 ---
 
-## Usage
+## ⚙️ Usage
 
 ### 1. Vite Configuration (`vite.config.js`)
 

--- a/tools/databases/data/inflections/README.md
+++ b/tools/databases/data/inflections/README.md
@@ -2,17 +2,15 @@
 
 ## Initial motivation
 
-Originally created to get the stem of an inflected form of a word, e.g., "took" would not be found in the Ontology
-because only the stem, "take", was in the Ontology.  A process known as [lemmatization](https://en.wikipedia.org/wiki/Lemmatization) is needed so "took" will result
-in "take" and that stem has a chance to be found.
+Originally created to get the stem of an inflected word — e.g. "took" wouldn't be found in the Ontology since only the stem "take" is stored there. [Lemmatization](https://en.wikipedia.org/wiki/Lemmatization) resolves "took" → "take" so the stem can be found.
 
-> Services and existing libraries were considered but maintaining consistency with TBTA's generation process was important, data and rules.
+> Services and existing libraries were considered, but maintaining consistency with TBTA's generation process (data and rules) was important.
 
 ## Extracting word forms from TBTA
 
 1. Drop `./tbta_utils` into an up-to-date `TBTA` dir
 
-!!!!!!!   TODO: tbta_utils is currently available for all target platforms, these instructions should be updated to get those from the appropriate directory as well as the usage !!!!!!!
+> ⚠️ **TODO**: `tbta_utils` is now available for all target platforms — these instructions should be updated to pull it from the right per-platform directory and cover its usage there too.
 
 1. Run `tbta_utils export-lexical-forms --language English --output-path <output directory>`
 1. Place all `*.win.txt` files into the `win` directory

--- a/tools/databases/data/status/README.md
+++ b/tools/databases/data/status/README.md
@@ -1,10 +1,10 @@
-# Download instructions
+# 📥 Download instructions
 
-1. Goto <https://datastudio.google.com/u/0/reporting/f5a0180a-9640-4f7d-9673-6ef2fb9d1dfc/page/IQdwE>
+1. Go to <https://datastudio.google.com/u/0/reporting/f5a0180a-9640-4f7d-9673-6ef2fb9d1dfc/page/IQdwE>
 1. Hover over table data for "New Testament" and click the 3-dot menu in the top-right corner of that table.
-1. Click "Export chart..." => "Export data"
+1. Click "Export chart..." → "Export data"
 1. Rename to `NT_verse_status_YYYY-MM-DD` (date should be the same date being used for the migration run)
 1. Export As... `CSV`
 1. Save in `sources/status` folder
 
-> Repeat for "Old Testament" => `OT_verse_status_YYYY-MM-DD`
+> Repeat for "Old Testament" → `OT_verse_status_YYYY-MM-DD`


### PR DESCRIPTION
## Summary
- Documents the lightweight GitHub Flow branching convention: regular work goes branch → PR → review + CI → squash-merge; urgent hotfixes/patches may push straight to `main` via GitHub's existing admin bypass on branch protection.
- Tightens wordy prose and adds consistent header emoji across user-facing docs (root README, CONTRIBUTING, all 5 app READMEs, e2e/vite-config/tools-databases READMEs, ADR format guide) for faster scanning.
- Agent-facing docs (`AGENTS.md`, skills) and historical ADR records were intentionally left untouched.

## Test plan
- [x] `pnpm check:md` passes with 0 errors