### PR TITLE
Add typecheck/lint/test coverage to scripts/

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -660,6 +660,31 @@ importers:
         specifier: ^8.2.0
         version: 8.2.0(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)
 
+  scripts:
+    dependencies:
+      sharp:
+        specifier: ^0.35.3
+        version: 0.35.3(@types/node@26.2.0)
+    devDependencies:
+      '@tabitha/eslint-config':
+        specifier: workspace:*
+        version: link:../packages/eslint-config
+      '@tabitha/tsconfig':
+        specifier: workspace:*
+        version: link:../packages/tsconfig
+      '@types/bun':
+        specifier: ^1.3.14
+        version: 1.3.14
+      '@types/node':
+        specifier: ^26.2.0
+        version: 26.2.0
+      eslint:
+        specifier: ^10.8.1
+        version: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+
   tools/databases:
     dependencies:
       officeparser:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ packages:
   - 'apps/*'
   - 'packages/*'
   - 'tools/*'
+  - 'scripts'
 
 allowBuilds:
   '@google/genai': true

--- a/scripts/audits/check_cloudflare.ts
+++ b/scripts/audits/check_cloudflare.ts
@@ -8,12 +8,19 @@ const script_dir = fileURLToPath(new URL('.', import.meta.url))
 const root_dir = resolve(script_dir, '../..')
 const apps_dir = join(root_dir, 'apps')
 
-interface CloudflareFinding {
+type CloudflareFinding = {
 	app_name: string
 	file_path: string
 	line_number?: number
 	message: string
 	severity: 'warning' | 'error'
+}
+
+type WranglerConfig = {
+	compatibility_flags?: string[]
+	compatibility_date?: string
+	vars?: Record<string, string>
+	d1_databases?: { binding?: string, database_name?: string, database_id?: string }[]
 }
 
 // Where this check's rationale and remediation steps are documented.
@@ -40,16 +47,16 @@ export async function check_cloudflare_configs(): Promise<{ valid: boolean; erro
 		if (!existsSync(wrangler_path)) continue
 
 		const raw_content = await readFile(wrangler_path, 'utf-8')
-		let config: Record<string, any>
+		let config: WranglerConfig
 
 		try {
 			const cleaned = strip_jsonc_comments(raw_content)
 			config = JSON.parse(cleaned)
-		} catch (err: any) {
+		} catch (err) {
 			local_findings.push({
 				app_name,
 				file_path: wrangler_path,
-				message: `Failed to parse wrangler.jsonc as valid JSONC: ${err?.message || err}`,
+				message: `Failed to parse wrangler.jsonc as valid JSONC: ${err instanceof Error ? err.message : err}`,
 				severity: 'error',
 			})
 			continue
@@ -81,7 +88,7 @@ export async function check_cloudflare_configs(): Promise<{ valid: boolean; erro
 			})
 		}
 
-		const vars: Record<string, any> = config.vars || {}
+		const vars: Record<string, string> = config.vars || {}
 		for (const key of Object.keys(vars)) {
 			if (forbidden_var_keys.includes(key)) {
 				local_findings.push({

--- a/scripts/audits/check_missing_bin_deps.ts
+++ b/scripts/audits/check_missing_bin_deps.ts
@@ -98,7 +98,7 @@ async function get_scannable_source_files(dir: string): Promise<string[]> {
 			) {
 				continue
 			}
-			files.push(...(await get_scannable_source_files(full_path)))
+			files.push(...await get_scannable_source_files(full_path))
 		} else if (
 			(entry.name.endsWith('.ts') || entry.name.endsWith('.js')) &&
 			!entry.name.endsWith('.d.ts') &&

--- a/scripts/audits/check_philosophies.ts
+++ b/scripts/audits/check_philosophies.ts
@@ -1,3 +1,4 @@
+import { execSync } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import { readdir, readFile } from 'node:fs/promises'
 import { join, relative, resolve } from 'node:path'
@@ -47,7 +48,7 @@ async function get_source_files(dir: string): Promise<string[]> {
 			) {
 				continue
 			}
-			files.push(...(await get_source_files(full_path)))
+			files.push(...await get_source_files(full_path))
 		} else if (
 			(entry.name.endsWith('.ts') || entry.name.endsWith('.js') || entry.name.endsWith('.svelte')) &&
 			!entry.name.endsWith('.d.ts') &&
@@ -64,7 +65,6 @@ async function get_source_files(dir: string): Promise<string[]> {
 function get_changed_files(): Set<string> {
 	const changed = new Set<string>()
 	try {
-		const { execSync } = require('node:child_process')
 		const base_ref = process.env.GITHUB_BASE_REF ? `origin/${process.env.GITHUB_BASE_REF}` : 'origin/main'
 		let output = ''
 		try {
@@ -128,7 +128,7 @@ async function audit_codebase() {
 		const lines = content.split('\n')
 
 		check_tabs_indentation(file_path, lines)
-		check_classes_at_end(file_path, content, lines)
+		check_classes_at_end(file_path, content)
 		check_strict_domain_typing(file_path, lines)
 		check_snake_case_functions(file_path, lines)
 		check_pure_functions(file_path, content, native_callback_names)
@@ -170,7 +170,7 @@ async function audit_codebase() {
 	const summary_file = process.env.GITHUB_STEP_SUMMARY
 	if (is_ci && summary_file) {
 		const { appendFile } = await import('node:fs/promises')
-		let markdown = `## 🏛️ Architectural Philosophy & Compliance\n\n`
+		let markdown = '## 🏛️ Architectural Philosophy & Compliance\n\n'
 		if (findings.length === 0) {
 			markdown += `✨ **100% Compliance!** All ${all_files.length} inspected source files adhere to the Development Philosophies.\n\n`
 		} else {
@@ -184,24 +184,24 @@ async function audit_codebase() {
 			const pr_findings = findings.filter(f => changed_files.has(f.file_path))
 			if (pr_findings.length > 0) {
 				markdown += `### ✏️ Observations in PR-Modified Files (${pr_findings.length})\n\n`
-				markdown += `| Rule | Location | Observation | Docs |\n`
-				markdown += `| :--- | :--- | :--- | :--- |\n`
+				markdown += '| Rule | Location | Observation | Docs |\n'
+				markdown += '| :--- | :--- | :--- | :--- |\n'
 				for (const f of pr_findings) {
 					const rel_path = relative(root_dir, f.file_path)
 					markdown += `| **#${f.rule_id} (${f.rule_title})** | [\`${rel_path}#L${f.line_number}\`](https://github.com/${repo}/blob/${sha}/${rel_path}#L${f.line_number}) | ${f.message} | ${doc_link(f.rule_id)} |\n`
 				}
-				markdown += `\n`
+				markdown += '\n'
 			}
 
 			markdown += `### 🌐 All Workspace Observations (${findings.length})\n\n`
-			markdown += `| Scope | Rule | Location | Observation | Docs |\n`
-			markdown += `| :--- | :--- | :--- | :--- | :--- |\n`
+			markdown += '| Scope | Rule | Location | Observation | Docs |\n'
+			markdown += '| :--- | :--- | :--- | :--- | :--- |\n'
 			for (const f of findings) {
 				const rel_path = relative(root_dir, f.file_path)
 				const scope = changed_files.has(f.file_path) ? '✏️ **PR File**' : '📄 Workspace'
 				markdown += `| ${scope} | **#${f.rule_id} (${f.rule_title})** | [\`${rel_path}#L${f.line_number}\`](https://github.com/${repo}/blob/${sha}/${rel_path}#L${f.line_number}) | ${f.message} | ${doc_link(f.rule_id)} |\n`
 			}
-			markdown += `\n`
+			markdown += '\n'
 		}
 		await appendFile(summary_file, markdown, 'utf-8')
 	}

--- a/scripts/audits/check_readme_badges.test.ts
+++ b/scripts/audits/check_readme_badges.test.ts
@@ -111,7 +111,7 @@ describe('README Badge Synchronization & Verification', () => {
 
 	describe('Live Workspace Synchronization', () => {
 		it('verifies or auto-syncs live README.md', async () => {
-			const sync_result = await sync_readme_badges({ should_write: true })
+			await sync_readme_badges({ should_write: true })
 			const verify_result = await sync_readme_badges({ should_write: false })
 			expect(verify_result.is_synced).toBe(true)
 			expect(verify_result.findings.length).toBe(0)

--- a/scripts/audits/check_readme_badges.ts
+++ b/scripts/audits/check_readme_badges.ts
@@ -82,7 +82,7 @@ export const audit_and_sync_badge_content = ({
 	let updated_content = content
 
 	// 1. pnpm badge check
-	const pnpm_badge_regex = /<a href="https:\/\/pnpm\.io"><img src="https:\/\/img\.shields\.io\/badge\/pnpm-([^-\?]+)-F69220[^"]*" alt="pnpm" \/><\/a>/
+	const pnpm_badge_regex = /<a href="https:\/\/pnpm\.io"><img src="https:\/\/img\.shields\.io\/badge\/pnpm-([^-?]+)-F69220[^"]*" alt="pnpm" \/><\/a>/
 	const pnpm_match = updated_content.match(pnpm_badge_regex)
 	if (pnpm_match) {
 		const current_pnpm = pnpm_match[1]
@@ -106,7 +106,7 @@ export const audit_and_sync_badge_content = ({
 	}
 
 	// 2. Svelte badge check
-	const svelte_badge_regex = /<a href="https:\/\/svelte\.dev"><img src="https:\/\/img\.shields\.io\/badge\/Svelte-([^-\?]+)-FF3E00[^"]*" alt="Svelte [^"]*" \/><\/a>/
+	const svelte_badge_regex = /<a href="https:\/\/svelte\.dev"><img src="https:\/\/img\.shields\.io\/badge\/Svelte-([^-?]+)-FF3E00[^"]*" alt="Svelte [^"]*" \/><\/a>/
 	const svelte_match = updated_content.match(svelte_badge_regex)
 	if (svelte_match) {
 		const current_svelte = svelte_match[1]
@@ -130,7 +130,7 @@ export const audit_and_sync_badge_content = ({
 	}
 
 	// 3. Tailwind CSS badge check
-	const tailwind_badge_regex = /<a href="https:\/\/tailwindcss\.com"><img src="https:\/\/img\.shields\.io\/badge\/Tailwind_CSS-([^-\?]+)-06B6D4[^"]*" alt="Tailwind CSS [^"]*" \/><\/a>/
+	const tailwind_badge_regex = /<a href="https:\/\/tailwindcss\.com"><img src="https:\/\/img\.shields\.io\/badge\/Tailwind_CSS-([^-?]+)-06B6D4[^"]*" alt="Tailwind CSS [^"]*" \/><\/a>/
 	const tailwind_match = updated_content.match(tailwind_badge_regex)
 	if (tailwind_match) {
 		const current_tailwind = tailwind_match[1]
@@ -154,7 +154,7 @@ export const audit_and_sync_badge_content = ({
 	}
 
 	// 4. daisyUI badge check
-	const daisyui_badge_regex = /<a href="https:\/\/daisyui\.com"><img src="https:\/\/img\.shields\.io\/badge\/daisyUI-([^-\?]+)-570DF8[^"]*" alt="daisyUI [^"]*" \/><\/a>/
+	const daisyui_badge_regex = /<a href="https:\/\/daisyui\.com"><img src="https:\/\/img\.shields\.io\/badge\/daisyUI-([^-?]+)-570DF8[^"]*" alt="daisyUI [^"]*" \/><\/a>/
 	const daisyui_match = updated_content.match(daisyui_badge_regex)
 	if (daisyui_match) {
 		const current_daisyui = daisyui_match[1]

--- a/scripts/audits/check_secrets.ts
+++ b/scripts/audits/check_secrets.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'node:url'
 const script_dir = fileURLToPath(new URL('.', import.meta.url))
 const root_dir = resolve(script_dir, '../..')
 
-interface SecretFinding {
+type SecretFinding = {
 	rule_name: string
 	file_path: string
 	line_number: number
@@ -16,8 +16,6 @@ interface SecretFinding {
 
 // Where this check's rationale and remediation steps are documented.
 const DOC_LINK = 'README.md#verification--testing'
-
-const findings: SecretFinding[] = []
 
 const secret_patterns: Array<{ name: string; regex: RegExp; message: string }> = [
 	{
@@ -84,7 +82,7 @@ async function get_scannable_files(dir: string): Promise<string[]> {
 			) {
 				continue
 			}
-			files.push(...(await get_scannable_files(full_path)))
+			files.push(...await get_scannable_files(full_path))
 		} else {
 			// Scan source files, env files, config files, workflows
 			// Skip gitignored local env files (.env.local, .env.*.local)
@@ -100,51 +98,6 @@ async function get_scannable_files(dir: string): Promise<string[]> {
 function mask_secret(str: string): string {
 	if (str.length <= 8) return '****'
 	return str.slice(0, 4) + '****' + str.slice(-4)
-}
-
-function check_line_secrets(file_path: string, line: string, line_num: number) {
-	const trimmed = line.trim()
-	if (!trimmed) return
-
-	for (const pattern of secret_patterns) {
-		const match = line.match(pattern.regex)
-		if (match) {
-			findings.push({
-				rule_name: pattern.name,
-				file_path,
-				line_number: line_num,
-				snippet: mask_secret(match[0]),
-				message: pattern.message,
-			})
-		}
-	}
-}
-
-function check_env_template_sanitization(file_path: string, lines: string[]) {
-	// Base .env files committed to git must have empty values for sensitive secrets
-	const file_name = file_path.split('/').pop() ?? ''
-	if (file_name !== '.env') return
-
-	lines.forEach((line, idx) => {
-		const trimmed = line.trim()
-		if (!trimmed || trimmed.startsWith('#')) return
-
-		const eq_idx = trimmed.indexOf('=')
-		if (eq_idx === -1) return
-
-		const key = trimmed.slice(0, eq_idx).trim()
-		const val = trimmed.slice(eq_idx + 1).trim()
-
-		if (sensitive_env_keys.includes(key) && val !== '') {
-			findings.push({
-				rule_name: 'Committed .env Secret',
-				file_path,
-				line_number: idx + 1,
-				snippet: `${key}=${mask_secret(val)}`,
-				message: `Committed base .env file has populated value for sensitive key "${key}". Base .env must be an empty template.`,
-			})
-		}
-	})
 }
 
 export async function scan_secrets(): Promise<{ scanned: number; found: number; findings: SecretFinding[] }> {

--- a/scripts/audits/check_storage.ts
+++ b/scripts/audits/check_storage.ts
@@ -56,7 +56,7 @@ async function get_scannable_source_files(dir: string): Promise<string[]> {
 			) {
 				continue
 			}
-			files.push(...(await get_scannable_source_files(full_path)))
+			files.push(...await get_scannable_source_files(full_path))
 		} else if (
 			(entry.name.endsWith('.ts') ||
 				entry.name.endsWith('.js') ||

--- a/scripts/audits/philosophies/classes_at_end.ts
+++ b/scripts/audits/philosophies/classes_at_end.ts
@@ -1,6 +1,6 @@
 import { findings } from './types'
 
-export function check_classes_at_end(file_path: string, content: string, lines: string[]) {
+export function check_classes_at_end(file_path: string, content: string) {
 	// Philosophy 5: Classes at the end of elements (in .svelte files)
 	if (!file_path.endsWith('.svelte')) return
 

--- a/scripts/ci/report_coverage.ts
+++ b/scripts/ci/report_coverage.ts
@@ -1,7 +1,7 @@
 import { $ } from 'bun'
 import { appendFile } from 'node:fs/promises'
 
-interface PackageConfig {
+type PackageConfig = {
 	name: string
 	pkg: string
 	/** Package has @vitest/coverage-v8 wired up and can run `vitest --coverage`. */
@@ -10,7 +10,7 @@ interface PackageConfig {
 	hasTestScript: boolean
 }
 
-interface CoverageMetrics {
+type CoverageMetrics = {
 	name: string
 	pkg: string
 	testCount: number
@@ -181,25 +181,25 @@ async function run_coverage_report() {
 		const total_tests = results.reduce((acc, r) => acc + r.testCount, 0)
 		const total_files = results.reduce((acc, r) => acc + r.fileCount, 0)
 
-		let markdown = `## 📊 Test Suite & Code Coverage Summary\n\n`
+		let markdown = '## 📊 Test Suite & Code Coverage Summary\n\n'
 		markdown += `✨ **${total_tests} Unit Tests Executed across ${total_files} Test Suites**\n\n`
 
-		markdown += `### 📈 Code Coverage Metrics\n\n`
-		markdown += `| Subsystem / Package | Statements | Branches | Functions | Lines | Status |\n`
-		markdown += `| :--- | :--- | :--- | :--- | :--- | :--- |\n`
+		markdown += '### 📈 Code Coverage Metrics\n\n'
+		markdown += '| Subsystem / Package | Statements | Branches | Functions | Lines | Status |\n'
+		markdown += '| :--- | :--- | :--- | :--- | :--- | :--- |\n'
 		for (const r of results) {
 			markdown += `| **${r.name}** | \`${r.statements}\` | \`${r.branches}\` | \`${r.functions}\` | \`${r.lines}\` | ${r.status} |\n`
 		}
-		markdown += `\n`
+		markdown += '\n'
 
-		markdown += `### 🧪 Test Suite Breakdown\n\n`
-		markdown += `| Workspace Test Suite | Test Files | Total Tests | Status |\n`
-		markdown += `| :--- | :--- | :--- | :--- |\n`
+		markdown += '### 🧪 Test Suite Breakdown\n\n'
+		markdown += '| Workspace Test Suite | Test Files | Total Tests | Status |\n'
+		markdown += '| :--- | :--- | :--- | :--- |\n'
 		for (const r of results) {
 			markdown += `| **${r.pkg}** | ${r.fileCount} files | ${r.testCount} tests | ${r.status} |\n`
 		}
-		markdown += `\n`
-		markdown += `> Pure in-memory unit tests with zero network or database dependencies.\n`
+		markdown += '\n'
+		markdown += '> Pure in-memory unit tests with zero network or database dependencies.\n'
 
 		await appendFile(summary_file, markdown, 'utf-8')
 		console.log('📝 Published full coverage dashboard to GitHub Step Summary.')

--- a/scripts/dx/db_load.ts
+++ b/scripts/dx/db_load.ts
@@ -12,13 +12,13 @@ const root_dir = resolve(script_dir, '../..')
 const snapshots_dir = join(root_dir, 'tools/databases/snapshots')
 const workerd_hash_cache_path = join(root_dir, 'tools/databases/.d1-workerd-hash-cache.json')
 
-export interface D1DatabaseEntry {
+export type D1DatabaseEntry = {
 	binding?: string
 	database_name: string
 	database_id: string
 }
 
-export interface AppConfig {
+export type AppConfig = {
 	app_dir: string
 	wrangler_path: string
 }

--- a/scripts/dx/db_status.ts
+++ b/scripts/dx/db_status.ts
@@ -9,12 +9,12 @@ const script_dir = dirname(fileURLToPath(import.meta.url))
 const root_dir = resolve(script_dir, '../..')
 const snapshots_dir = join(root_dir, 'tools', 'databases', 'snapshots')
 
-interface TableInfo {
+type TableInfo = {
 	name: string
 	rows: number
 }
 
-interface DbStatus {
+type DbStatus = {
 	app: string
 	binding: string
 	database_name: string
@@ -27,10 +27,14 @@ interface DbStatus {
 	snapshot_size_bytes: number
 }
 
-interface D1Config {
+type D1Config = {
 	binding: string
 	database_name: string
 	database_id: string
+}
+
+type WranglerD1Config = {
+	d1_databases?: { binding?: string, database_name?: string, database_id?: string }[]
 }
 
 const APP_NAMES = ['ontology', 'sources', 'targets', 'editor', 'copilot']
@@ -42,9 +46,9 @@ function parse_wrangler_d1_configs(app_name: string): D1Config[] {
 	try {
 		const raw = readFileSync(wrangler_path, 'utf-8')
 		const cleaned = strip_jsonc_comments(raw)
-		const config = JSON.parse(cleaned)
+		const config: WranglerD1Config = JSON.parse(cleaned)
 		if (Array.isArray(config.d1_databases)) {
-			return config.d1_databases.map((db: any) => ({
+			return config.d1_databases.map(db => ({
 				binding: db.binding || 'D1_DATABASE',
 				database_name: db.database_name || 'unknown',
 				database_id: db.database_id || 'unknown',
@@ -122,7 +126,7 @@ export async function inspect_databases(): Promise<DbStatus[]> {
 			let matched_file: string | null = null
 			let file_size = 0
 			let last_mod: Date | null = null
-			let tables: TableInfo[] = []
+			const tables: TableInfo[] = []
 
 			const expected_hash = createHash('sha256').update(d1.database_id).digest('hex')
 			const expected_file = join(d1_dir, 'miniflare-D1DatabaseObject', `${expected_hash}.sqlite`)
@@ -139,7 +143,7 @@ export async function inspect_databases(): Promise<DbStatus[]> {
 					const is_auth = d1.binding.toLowerCase().includes('auth') || d1.database_name.toLowerCase().includes('auth')
 					const is_auth_table = table_names.includes('Users') || table_names.includes('Permissions')
 
-					if ((is_auth && is_auth_table) || (!is_auth && !is_auth_table && table_names.some(t => !t.startsWith('_cf_')))) {
+					if (is_auth && is_auth_table || !is_auth && !is_auth_table && table_names.some(t => !t.startsWith('_cf_'))) {
 						matched_file = file_path
 						const stat = statSync(file_path)
 						file_size = stat.size

--- a/scripts/dx/dev_menu.ts
+++ b/scripts/dx/dev_menu.ts
@@ -2,7 +2,7 @@ import { createInterface } from 'node:readline/promises'
 import { stdin as input, stdout as output } from 'node:process'
 import { spawn } from 'node:child_process'
 
-interface AppInfo {
+type AppInfo = {
 	id: string
 	pkg: string
 	name: string
@@ -48,7 +48,7 @@ const APPS: Record<string, AppInfo> = {
 	},
 }
 
-interface Preset {
+type Preset = {
 	name: string
 	description: string
 	apps: string[]

--- a/scripts/dx/doctor.ts
+++ b/scripts/dx/doctor.ts
@@ -7,7 +7,7 @@ import { check_cloudflare_configs } from '../audits/check_cloudflare'
 import { sync_readme_badges } from '../audits/check_readme_badges'
 import { scan_secrets } from '../audits/check_secrets'
 
-interface DiagnosticResult {
+type DiagnosticResult = {
 	category: string
 	name: string
 	status: 'PASS' | 'WARN' | 'FAIL'
@@ -207,16 +207,16 @@ async function check_local_databases(): Promise<DiagnosticResult[]> {
 					name: `D1 Database (${app.name})`,
 					status: 'WARN',
 					message: `Database exists but table '${app.table}' has 0 rows`,
-					fix: `Run \`pnpm db:load\` to populate tables`,
+					fix: 'Run `pnpm db:load` to populate tables',
 				})
 			}
-		} catch (err: any) {
+		} catch (err) {
 			results.push({
 				category: 'Local Databases',
 				name: `D1 Database (${app.name})`,
 				status: 'WARN',
-				message: `Error querying SQLite: ${err?.message || err}`,
-				fix: `Run \`pnpm db:load\` to re-bootstrap SQLite snapshot`,
+				message: `Error querying SQLite: ${err instanceof Error ? err.message : err}`,
+				fix: 'Run `pnpm db:load` to re-bootstrap SQLite snapshot',
 			})
 		}
 	}
@@ -246,12 +246,12 @@ async function check_security_and_cloudflare(): Promise<DiagnosticResult[]> {
 				fix: 'Run `pnpm check:secrets` for line-by-line inspection',
 			})
 		}
-	} catch (err: any) {
+	} catch (err) {
 		results.push({
 			category: 'Quality & Security',
 			name: 'Credential & Secret Scanner',
 			status: 'WARN',
-			message: `Could not run scanner: ${err?.message || err}`,
+			message: `Could not run scanner: ${err instanceof Error ? err.message : err}`,
 		})
 	}
 
@@ -274,12 +274,12 @@ async function check_security_and_cloudflare(): Promise<DiagnosticResult[]> {
 				fix: 'Run `pnpm check:cloudflare` for details',
 			})
 		}
-	} catch (err: any) {
+	} catch (err) {
 		results.push({
 			category: 'Quality & Security',
 			name: 'Cloudflare Wrangler Configs',
 			status: 'WARN',
-			message: `Could not check Cloudflare configs: ${err?.message || err}`,
+			message: `Could not check Cloudflare configs: ${err instanceof Error ? err.message : err}`,
 		})
 	}
 
@@ -302,12 +302,12 @@ async function check_security_and_cloudflare(): Promise<DiagnosticResult[]> {
 				fix: 'Run `bun scripts/audits/check_readme_badges.ts --fix` to sync badges',
 			})
 		}
-	} catch (err: any) {
+	} catch (err) {
 		results.push({
 			category: 'Quality & Security',
 			name: 'README Badges Sync',
 			status: 'WARN',
-			message: `Could not check README badges: ${err?.message || err}`,
+			message: `Could not check README badges: ${err instanceof Error ? err.message : err}`,
 		})
 	}
 
@@ -322,10 +322,10 @@ export async function run_doctor(): Promise<{ all_passed: boolean; fixes: string
 `)
 
 	const results: DiagnosticResult[] = [
-		...(await check_runtimes()),
-		...(await check_env_files()),
-		...(await check_local_databases()),
-		...(await check_security_and_cloudflare()),
+		...await check_runtimes(),
+		...await check_env_files(),
+		...await check_local_databases(),
+		...await check_security_and_cloudflare(),
 	]
 
 	// Group by category

--- a/scripts/dx/grant_permission.ts
+++ b/scripts/dx/grant_permission.ts
@@ -62,7 +62,7 @@ async function grant_permission(email: string, permissions?: string[]) {
 	db.prepare('INSERT OR REPLACE INTO Users (email, name) VALUES (?, ?)').run(email, email)
 
 	let granted = 0
-	for (const { id, permission } of to_grant) {
+	for (const { id } of to_grant) {
 		const existing = db.prepare('SELECT 1 FROM User_Permissions WHERE user_email = ? AND permission_id = ?').get(email, id)
 		if (!existing) {
 			db.prepare('INSERT INTO User_Permissions (user_email, permission_id) VALUES (?, ?)').run(email, id)

--- a/scripts/dx/lib/brand_mark.ts
+++ b/scripts/dx/lib/brand_mark.ts
@@ -29,8 +29,8 @@ const FONT_STACK = "ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto,
 // are shown at their own bounds rather than run through an OS mask shape.
 export function build_cell_svg(letter: string, size: number): string {
 	const inset = size / 64
-	const rx = (size / 64) * 4
-	const border = (size / 64) * 1.5
+	const rx = size / 64 * 4
+	const border = size / 64 * 1.5
 	return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${size} ${size}">
 	<rect x="${inset}" y="${inset}" width="${size - inset * 2}" height="${size - inset * 2}" rx="${rx}" fill="${CANIL_RED}" stroke="${CANIL_WHITE}" stroke-opacity="0.35" stroke-width="${border}" />
 	<text x="${size * 0.156}" y="${size * 0.266}" text-anchor="start" font-family="${FONT_STACK}" font-size="${size * 0.203}" font-weight="500" fill="${CANIL_WHITE}" fill-opacity="0.65">T</text>

--- a/scripts/dx/setup.ts
+++ b/scripts/dx/setup.ts
@@ -1,3 +1,4 @@
+import { $ } from 'bun'
 import { platform } from 'node:os'
 import { load_database } from './db_load'
 import { setup_env } from './setup_env'
@@ -58,8 +59,8 @@ async function setup_workspace() {
 	try {
 		await $`pnpm check`
 		console.log('✅ Workspace checks passed cleanly!')
-	} catch (err: any) {
-		console.warn('⚠️  Verification encountered an issue:', err?.message || err)
+	} catch (err) {
+		console.warn('⚠️  Verification encountered an issue:', err instanceof Error ? err.message : err)
 	}
 
 	console.log(`

--- a/scripts/dx/update_safe.ts
+++ b/scripts/dx/update_safe.ts
@@ -88,8 +88,8 @@ async function sync_ci_node_version() {
 				console.log(`   ✓ CI Node.js version is in sync (${current_ci_node})\n`)
 			}
 		}
-	} catch (err: any) {
-		console.warn('   ⚠️  Could not sync CI Node version:', err?.message || err)
+	} catch (err) {
+		console.warn('   ⚠️  Could not sync CI Node version:', err instanceof Error ? err.message : err)
 	}
 }
 
@@ -98,8 +98,8 @@ async function regenerate_worker_and_framework_types() {
 	try {
 		await $`pnpm --filter @tabitha/ontology exec wrangler types ./worker-configuration.d.ts`.quiet()
 		console.log('   ✓ Regenerated Cloudflare Worker types for ontology.\n')
-	} catch (err: any) {
-		console.warn('   ⚠️  Could not regenerate wrangler types:', err?.message || err)
+	} catch (err) {
+		console.warn('   ⚠️  Could not regenerate wrangler types:', err instanceof Error ? err.message : err)
 	}
 }
 
@@ -120,8 +120,8 @@ async function run_safe_update() {
 		console.log(`   • Node.js:  ${node_ver}`)
 		console.log(`   • Bun:      v${bun_ver}`)
 		console.log(`   • pnpm:     v${pnpm_ver}\n`)
-	} catch (err: any) {
-		console.warn('   ⚠️  Could not determine toolchain versions:', err?.message || err)
+	} catch (err) {
+		console.warn('   ⚠️  Could not determine toolchain versions:', err instanceof Error ? err.message : err)
 	}
 
 	// 2. Workspace Skills Audit
@@ -138,8 +138,8 @@ async function run_safe_update() {
 	try {
 		await $`pnpm update --recursive`
 		console.log('✅ Workspace dependencies safely updated!\n')
-	} catch (err: any) {
-		console.error('❌ Dependency update encountered an error:', err?.message || err)
+	} catch (err) {
+		console.error('❌ Dependency update encountered an error:', err instanceof Error ? err.message : err)
 		process.exit(1)
 	}
 
@@ -168,8 +168,8 @@ async function run_safe_update() {
 		} else {
 			console.log(`   ✨ Updated ${badge_res.findings.length} badge(s) in README.md.\n`)
 		}
-	} catch (err: any) {
-		console.warn('   ⚠️  Could not synchronize README badges:', err?.message || err)
+	} catch (err) {
+		console.warn('   ⚠️  Could not synchronize README badges:', err instanceof Error ? err.message : err)
 	}
 
 	// 9. Full-Repo Undeclared CLI Dependency Sweep
@@ -186,8 +186,8 @@ async function run_safe_update() {
 		} else {
 			console.warn(`   ⚠️  Found ${findings.length} undeclared CLI dependenc(y/ies) -- run "pnpm check:deps -- --all" for details.\n`)
 		}
-	} catch (err: any) {
-		console.warn('   ⚠️  Could not complete the undeclared CLI dependency sweep:', err?.message || err)
+	} catch (err) {
+		console.warn('   ⚠️  Could not complete the undeclared CLI dependency sweep:', err instanceof Error ? err.message : err)
 	}
 
 	// 10. Automated Post-Update Health Verification Gate
@@ -197,8 +197,8 @@ async function run_safe_update() {
 	try {
 		await $`pnpm check`
 		console.log('   ✓ Static analysis & typecheck passed cleanly!')
-	} catch (err: any) {
-		console.error('❌ Post-update check failed:', err?.message || err)
+	} catch (err) {
+		console.error('❌ Post-update check failed:', err instanceof Error ? err.message : err)
 		process.exit(1)
 	}
 
@@ -206,8 +206,8 @@ async function run_safe_update() {
 	try {
 		await $`pnpm test:unit`
 		console.log('   ✓ All unit test suites passed!')
-	} catch (err: any) {
-		console.error('❌ Post-update unit tests failed:', err?.message || err)
+	} catch (err) {
+		console.error('❌ Post-update unit tests failed:', err instanceof Error ? err.message : err)
 		process.exit(1)
 	}
 
@@ -215,8 +215,8 @@ async function run_safe_update() {
 	try {
 		await $`pnpm build`
 		console.log('   ✓ All 5 Cloudflare Worker bundles built successfully!')
-	} catch (err: any) {
-		console.error('❌ Post-update production build failed:', err?.message || err)
+	} catch (err) {
+		console.error('❌ Post-update production build failed:', err instanceof Error ? err.message : err)
 		process.exit(1)
 	}
 

--- a/scripts/eslint.config.js
+++ b/scripts/eslint.config.js
@@ -1,0 +1,13 @@
+import tabithaConfig from '@tabitha/eslint-config'
+
+export default [
+	...tabithaConfig,
+
+	// These are CLI tools run directly by a developer/CI, so console output is
+	// the intended product rather than debug noise to be flagged.
+	{
+		rules: {
+			'no-console': 'off',
+		},
+	},
+]

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@tabitha/scripts",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Monorepo-wide dev-experience and audit scripts",
+  "scripts": {
+    "check": "tsc --noEmit",
+    "check:lint": "eslint .",
+    "check:lint:fix": "eslint . --fix",
+    "test": "pnpm test:unit",
+    "test:unit": "bun test ."
+  },
+  "dependencies": {
+    "sharp": "^0.35.3"
+  },
+  "devDependencies": {
+    "@tabitha/eslint-config": "workspace:*",
+    "@tabitha/tsconfig": "workspace:*",
+    "@types/bun": "^1.3.14",
+    "@types/node": "^26.2.0",
+    "eslint": "^10.8.1",
+    "typescript": "^6.0.3"
+  }
+}

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,15 @@
+{
+	"extends": "@tabitha/tsconfig/base.json",
+	"compilerOptions": {
+		"types": [
+			"node",
+			"bun"
+		]
+	},
+	"include": [
+		"**/*.ts"
+	],
+	"exclude": [
+		"eslint.config.js"
+	]
+}


### PR DESCRIPTION
## Summary
- `scripts/` (both `dx/` and `audits/`) had zero tsconfig, eslint config, and was excluded from the pnpm workspace entirely -- `pnpm check`/`pnpm check:lint`/`pnpm test` never touched it, and 3 existing test files under `scripts/audits/` (22 tests) only ran if someone happened to invoke `bun test` there manually.
- Adds `scripts` as a real workspace package (`@tabitha/scripts`) with its own `tsconfig.json` (extending the shared strict base) and `eslint.config.js` (the shared config, `no-console` off since these are CLI tools). No script logic changes in that commit.
- Fixes everything the new tooling surfaced, split into two commits:
  - Mechanical lint fixes (quotes, redundant parens, `interface`->`type`, an unnecessary regex escape, `require()`->`import`) and dead-code removal -- most notably two orphaned functions in `check_secrets.ts` (`check_line_secrets`, `check_env_template_sanitization`) plus their backing module-level array, which `scan_secrets()` already reimplements identically inline. Confirmed this is leftover duplication from an earlier refactor, not a gap in actual secret-scanning coverage.
  - A real bug: `setup.ts` never imported `$` from `bun` (unlike `doctor.ts`/`update_safe.ts`, which both do), so any code path invoking it would throw `ReferenceError: $ is not defined`. Also replaces `catch (err: any)` with proper `instanceof Error` narrowing repo-wide in `scripts/`, and swaps `Record<string, any>` / untyped `JSON.parse` results in the two files that parse `wrangler.jsonc` for small local types describing the shape they actually read.

## Test plan
- [x] `tsc --noEmit` and `eslint .` both pass clean for the new `@tabitha/scripts` package
- [x] `pnpm test:unit --filter=@tabitha/scripts` now runs the previously-orphaned 22 tests through the standard turbo pipeline
- [x] Every live audit script (`check:secrets`, `check:storage`, `check:philosophies`, `check:deps`, `check:cloudflare`, `check:badges`, `check:doctor`) run manually with unchanged output
- [x] `bun build` sanity check on `setup.ts`/`update_safe.ts` (not safely runnable live -- they mutate git config / run installs)