### PR TITLE
feat(www): scaffold public marketing site app

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Built with **Svelte**, **SvelteKit**, **Tailwind CSS**, and **daisyUI**, deploye
 | **Sources** | `apps/sources` | `http://localhost:8789` | `8789` | [sources.tabitha.bible](https://sources.tabitha.bible) | Source text analysis and semantic encoding explorer |
 | **Editor** | `apps/editor` | `http://localhost:8790` | `8790` | [editor.tabitha.bible](https://editor.tabitha.bible) | Grammar & rule checker, backtranslator, AI assistant |
 | **Copilot** | `apps/copilot` | `http://localhost:8793` | `8793` | [copilot.tabitha.bible](https://copilot.tabitha.bible) | Translation notes, brief extraction, and AI copilot |
+| **www** | `apps/www` | `http://localhost:8791` | `8791` | [tabitha.bible](https://tabitha.bible) | Public-facing marketing/informational site |
 
 ---
 
@@ -41,7 +42,8 @@ tabitha/
 │   ├── editor/      # Semantic editor, rule parser & backtranslator
 │   ├── ontology/    # Central ontology database & concept management (Auth.js)
 │   ├── sources/     # Source entities, lookups, and feature explorer
-│   └── targets/     # Target grammar, project search, and lexicons
+│   ├── targets/     # Target grammar, project search, and lexicons
+│   └── www/         # Public-facing marketing/informational site
 ├── packages/
 │   ├── ai/             # Shared LLM plumbing: AI Gateway routing, retries, credentials (@tabitha/ai)
 │   ├── api-client/     # Typed HTTP clients for calling one app's API from another (@tabitha/api-client)

--- a/apps/www/README.md
+++ b/apps/www/README.md
@@ -1,0 +1,9 @@
+# www
+
+- **Live URL**: [https://tabitha.bible](https://tabitha.bible)
+- **Local Dev URL**: [http://localhost:8791](http://localhost:8791) (Port `8791`)
+
+Public-facing marketing/informational site for the TaBiThA project. Fully static
+(every route is prerendered), built with SvelteKit so interactivity can be added
+later without an adapter change. Content and design are still being scoped --
+see the project's backlog for the tiered-explainer plan this will grow into.

--- a/apps/www/eslint.config.js
+++ b/apps/www/eslint.config.js
@@ -1,0 +1,3 @@
+import tabithaConfig from '@tabitha/eslint-config'
+
+export default tabithaConfig

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -1,0 +1,50 @@
+{
+	"name": "@tabitha/www",
+	"version": "1.0.0",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"prepare": "svelte-kit sync",
+		"check": "pnpm prepare && (pnpm check:svelte & pnpm check:lint)",
+		"check:svelte": "svelte-check --tsconfig ./tsconfig.json",
+		"check:lint": "eslint .",
+		"check:lint:fix": "eslint . --fix",
+		"build": "vite build",
+		"dev": "vite dev",
+		"test": "pnpm test:unit && pnpm test:e2e",
+		"test:unit": "vitest run src",
+		"test:unit:watch": "vitest watch",
+		"test:unit:coverage": "vitest run --coverage",
+		"test:e2e": "playwright test",
+		"test:e2e:dev": "playwright test --ui",
+		"precommit": "pnpm check && pnpm build && pnpm test",
+		"clean:svelte": "rimraf .svelte-kit",
+		"clean:node": "rimraf node_modules",
+		"clean:powerwash": "(pnpm clean:svelte & pnpm clean:node) && pnpm install"
+	},
+	"dependencies": {
+		"@sveltejs/kit": "^2.70.2",
+		"@tabitha/ui": "workspace:*",
+		"@tailwindcss/typography": "^0.5.20",
+		"daisyui": "^5.7.17",
+		"svelte": "^5.56.9",
+		"tailwindcss": "^4.3.3"
+	},
+	"devDependencies": {
+		"@eslint/compat": "^2.1.0",
+		"@playwright/test": "^1.62.1",
+		"@sveltejs/adapter-cloudflare": "^7.2.9",
+		"@sveltejs/vite-plugin-svelte": "^7.3.0",
+		"@tabitha/eslint-config": "workspace:*",
+		"@tabitha/vite-config": "workspace:*",
+		"@tailwindcss/vite": "^4.3.3",
+		"@vitest/coverage-v8": "^3.2.7",
+		"eslint": "^10.8.1",
+		"rimraf": "^6.1.3",
+		"svelte-check": "^4.7.6",
+		"typescript": "^6.0.3",
+		"vite": "8.2.0",
+		"vitest": "^3.2.7",
+		"wrangler": "^4.123.0"
+	}
+}

--- a/apps/www/playwright.config.js
+++ b/apps/www/playwright.config.js
@@ -1,0 +1,3 @@
+import { create_app_playwright_config } from '@tabitha/vite-config/playwright'
+
+export default create_app_playwright_config({ port: 8791 })

--- a/apps/www/src/app.d.ts
+++ b/apps/www/src/app.d.ts
@@ -1,0 +1,12 @@
+// See https://kit.svelte.dev/docs/types#app
+// for information about these interfaces
+declare global {
+	namespace App {
+		// interface Error {}
+		// interface Locals {}
+		// interface PageData {}
+		// interface Platform {}
+	}
+}
+
+export {}

--- a/apps/www/src/app.html
+++ b/apps/www/src/app.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width" />
+
+		<link rel="icon" type="image/svg+xml" href="%sveltekit.assets%/favicon.svg" />
+		%sveltekit.head%
+	</head>
+
+	<body data-sveltekit-preload-data="hover">
+		<!-- why this extra div is advised: https://kit.svelte.dev/docs/project-structure#project-files-src -->
+		<div style="display: contents">%sveltekit.body%</div>
+	</body>
+</html>

--- a/apps/www/src/lib/app.css
+++ b/apps/www/src/lib/app.css
@@ -1,0 +1,9 @@
+@import '@tabitha/ui/theme.css';
+
+h1, h2, h3, h4, .text-balance {
+	text-wrap: balance;
+}
+
+p, article {
+	text-wrap: pretty;
+}

--- a/apps/www/src/routes/+layout.svelte
+++ b/apps/www/src/routes/+layout.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import '$lib/app.css'
+	import type { Snippet } from 'svelte'
+
+	let { children }: { children?: Snippet } = $props()
+</script>
+
+<header class="mx-8 mt-8">
+	<a href="/" class="text-xl font-bold">TaBiThA</a>
+</header>
+
+<main class="mx-8 mt-8">
+	{#if children}
+		{@render children()}
+	{/if}
+</main>
+
+<footer class="mx-8 mt-8 mb-8">
+	<a href="https://github.com/presciencelabs/tabitha" class="link link-hover">GitHub</a>
+</footer>

--- a/apps/www/src/routes/+layout.ts
+++ b/apps/www/src/routes/+layout.ts
@@ -1,0 +1,3 @@
+// The whole site is static content -- prerender every route so the app
+// builds to plain assets rather than running as a live SSR worker.
+export const prerender = true

--- a/apps/www/src/routes/+page.svelte
+++ b/apps/www/src/routes/+page.svelte
@@ -1,0 +1,4 @@
+<h1 class="text-4xl font-bold">TaBiThA</h1>
+<p class="mt-4 max-w-prose">
+	This page is a placeholder -- content and design for the public site are still being scoped.
+</p>

--- a/apps/www/static/favicon.svg
+++ b/apps/www/static/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+	<rect x="1" y="1" width="62" height="62" rx="4" fill="#d02031" stroke="#ffffff" stroke-opacity="0.35" stroke-width="1.5" />
+	<text x="9.984" y="17.024" text-anchor="start" font-family="ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-size="12.992" font-weight="500" fill="#ffffff" fill-opacity="0.65">T</text>
+	<text x="32" y="44.032" text-anchor="middle" font-family="ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-size="32" font-weight="700" fill="#ffffff">W</text>
+</svg>

--- a/apps/www/svelte.config.js
+++ b/apps/www/svelte.config.js
@@ -1,0 +1,3 @@
+import { create_app_svelte_config } from '@tabitha/vite-config/svelte'
+
+export default create_app_svelte_config()

--- a/apps/www/tsconfig.json
+++ b/apps/www/tsconfig.json
@@ -1,0 +1,14 @@
+{
+	"extends": "./.svelte-kit/tsconfig.json",
+	"compilerOptions": {
+		"allowJs": true,
+		"checkJs": true,
+		"esModuleInterop": true,
+		"forceConsistentCasingInFileNames": true,
+		"resolveJsonModule": true,
+		"skipLibCheck": true,
+		"sourceMap": true,
+		"strict": true,
+		"moduleResolution": "bundler"
+	}
+}

--- a/apps/www/vite.config.js
+++ b/apps/www/vite.config.js
@@ -1,0 +1,3 @@
+import { create_app_vite_config } from '@tabitha/vite-config'
+
+export default create_app_vite_config({ port: 8791 })

--- a/apps/www/wrangler.jsonc
+++ b/apps/www/wrangler.jsonc
@@ -1,0 +1,25 @@
+{
+	"$schema": "./node_modules/wrangler/config-schema.json",
+	"name": "www",
+	"compatibility_date": "2026-08-15",
+	"compatibility_flags": [
+		"nodejs_compat"
+	],
+	"main": ".svelte-kit/cloudflare/_worker.js",
+	"assets": {
+		"binding": "ASSETS",
+		"directory": ".svelte-kit/cloudflare"
+	},
+	"workers_dev": true,
+	"preview_urls": true,
+	"observability": {
+		"enabled": true,
+		"head_sampling_rate": 1
+	},
+	"routes": [
+		{
+			"pattern": "tabitha.bible",
+			"custom_domain": true
+		}
+	]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -509,6 +509,73 @@ importers:
         specifier: ^4.123.0
         version: 4.123.0(@cloudflare/workers-types@5.20260815.1)
 
+  apps/www:
+    dependencies:
+      '@sveltejs/kit':
+        specifier: ^2.70.2
+        version: 2.70.2(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)))(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@6.0.3)(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0))
+      '@tabitha/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
+      '@tailwindcss/typography':
+        specifier: ^0.5.20
+        version: 0.5.20(tailwindcss@4.3.3)
+      daisyui:
+        specifier: ^5.7.17
+        version: 5.7.17
+      svelte:
+        specifier: ^5.56.9
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
+      tailwindcss:
+        specifier: ^4.3.3
+        version: 4.3.3
+    devDependencies:
+      '@eslint/compat':
+        specifier: ^2.1.0
+        version: 2.1.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
+      '@playwright/test':
+        specifier: ^1.62.1
+        version: 1.62.1
+      '@sveltejs/adapter-cloudflare':
+        specifier: ^7.2.9
+        version: 7.2.9(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)))(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@6.0.3)(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)))(wrangler@4.123.0(@cloudflare/workers-types@5.20260815.1))
+      '@sveltejs/vite-plugin-svelte':
+        specifier: ^7.3.0
+        version: 7.3.0(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0))
+      '@tabitha/eslint-config':
+        specifier: workspace:*
+        version: link:../../packages/eslint-config
+      '@tabitha/vite-config':
+        specifier: workspace:*
+        version: link:../../packages/vite-config
+      '@tailwindcss/vite':
+        specifier: ^4.3.3
+        version: 4.3.3(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0))
+      '@vitest/coverage-v8':
+        specifier: ^3.2.7
+        version: 3.2.7(supports-color@10.2.2)(vitest@3.2.7(@types/debug@4.1.13)(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(supports-color@10.2.2)(terser@5.50.0))
+      eslint:
+        specifier: ^10.8.1
+        version: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
+      rimraf:
+        specifier: ^6.1.3
+        version: 6.1.3
+      svelte-check:
+        specifier: ^4.7.6
+        version: 4.7.6(picomatch@4.0.5)(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@6.0.3)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vite:
+        specifier: 8.2.0
+        version: 8.2.0(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)
+      vitest:
+        specifier: ^3.2.7
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(supports-color@10.2.2)(terser@5.50.0)
+      wrangler:
+        specifier: ^4.123.0
+        version: 4.123.0(@cloudflare/workers-types@5.20260815.1)
+
   packages/ai:
     dependencies:
       '@google/genai':

--- a/scripts/audits/check_cloudflare.ts
+++ b/scripts/audits/check_cloudflare.ts
@@ -33,15 +33,17 @@ const forbidden_var_keys = [
 	'AI_GATEWAY_TOKEN',
 ]
 
-export async function check_cloudflare_configs(): Promise<{ valid: boolean; errors: CloudflareFinding[]; warnings: CloudflareFinding[] }> {
+export async function check_cloudflare_configs(): Promise<{ valid: boolean; errors: CloudflareFinding[]; warnings: CloudflareFinding[]; wrangler_config_count: number }> {
 	const local_findings: CloudflareFinding[] = []
 
 	const app_entries = await readdir(apps_dir, { withFileTypes: true })
 	const app_dirs = app_entries.filter(d => d.isDirectory()).map(d => d.name)
 
+	let wrangler_config_count = 0
 	for (const app_name of app_dirs) {
 		const wrangler_path = join(apps_dir, app_name, 'wrangler.jsonc')
 		if (!existsSync(wrangler_path)) continue
+		wrangler_config_count++
 
 		const raw_content = await readFile(wrangler_path, 'utf-8')
 		let config: WranglerConfig
@@ -118,6 +120,7 @@ export async function check_cloudflare_configs(): Promise<{ valid: boolean; erro
 		valid: errors.length === 0,
 		errors,
 		warnings,
+		wrangler_config_count,
 	}
 }
 
@@ -132,7 +135,7 @@ async function audit_cloudflare_configs() {
 	const all_findings = [...result.errors, ...result.warnings]
 
 	if (all_findings.length === 0) {
-		console.log('✅ 100% Valid! All 5 wrangler.jsonc files comply with Cloudflare Workers best practices.\n')
+		console.log(`✅ 100% Valid! All ${result.wrangler_config_count} wrangler.jsonc files comply with Cloudflare Workers best practices.\n`)
 		return
 	}
 

--- a/scripts/dx/lib/brand_mark.ts
+++ b/scripts/dx/lib/brand_mark.ts
@@ -11,6 +11,7 @@ export const APP_LETTERS: Record<string, string> = {
 	ontology: 'O',
 	sources: 'S',
 	targets: 'T',
+	www: 'W',
 }
 
 // CANIL's brand red, sampled directly from the pixels of their own favicon


### PR DESCRIPTION
## Summary
- New `apps/www`: static SvelteKit app for TaBiThA's public-facing site, replacing the Google Sites page at tabitha.presciencelabs.org
- Routed to root `tabitha.bible`, fully prerendered, deliberately lean (no PWA/CORS/D1 -- not needed for a marketing site)
- Fixes a stale hardcoded count in `check_cloudflare.ts`'s success message

Placeholder content only. This PR will grow with additional commits for real content/copy and the Cloudflare deployment before merge -- opening it now (rather than after) so CI runs against it and it doesn't drift from `main` in the meantime.

## Test plan
- [x] `pnpm --filter @tabitha/www check` (svelte-check + eslint, 0 errors)
- [x] `pnpm --filter @tabitha/www build` (prerenders to static `index.html`)
- [x] `check_cloudflare` / `check_secrets` / `check_readme_badges` / markdownlint audits pass
- [x] Dev server manually verified at `localhost:8791`
- [ ] Real content pass
- [ ] Cloudflare deployment wired up

🤖 Generated with [Claude Code](https://claude.com/claude-code)