### PR TITLE
feat(www): add Home page content and warm-editorial theme

### DIFF
--- a/apps/www/README.md
+++ b/apps/www/README.md
@@ -5,5 +5,7 @@
 
 Public-facing marketing/informational site for the TaBiThA project. Fully static
 (every route is prerendered), built with SvelteKit so interactivity can be added
-later without an adapter change. Content and design are still being scoped --
-see the project's backlog for the tiered-explainer plan this will grow into.
+later without an adapter change. The Home page (Level 0 of the tiered-explainer
+plan) has real content and a warm-editorial theme (Spectral/Work Sans, terracotta/
+teal); the rest of the sitemap and the Cloudflare deployment are still to come --
+see the project's backlog for the full plan.

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -11,10 +11,7 @@
 		"check:lint:fix": "eslint . --fix",
 		"build": "vite build",
 		"dev": "vite dev",
-		"test": "pnpm test:unit && pnpm test:e2e",
-		"test:unit": "vitest run src",
-		"test:unit:watch": "vitest watch",
-		"test:unit:coverage": "vitest run --coverage",
+		"test": "pnpm test:e2e",
 		"test:e2e": "playwright test",
 		"test:e2e:dev": "playwright test --ui",
 		"precommit": "pnpm check && pnpm build && pnpm test",
@@ -38,13 +35,11 @@
 		"@tabitha/eslint-config": "workspace:*",
 		"@tabitha/vite-config": "workspace:*",
 		"@tailwindcss/vite": "^4.3.3",
-		"@vitest/coverage-v8": "^3.2.7",
 		"eslint": "^10.8.1",
 		"rimraf": "^6.1.3",
 		"svelte-check": "^4.7.6",
 		"typescript": "^6.0.3",
 		"vite": "8.2.0",
-		"vitest": "^3.2.7",
 		"wrangler": "^4.123.0"
 	}
 }

--- a/apps/www/src/app.html
+++ b/apps/www/src/app.html
@@ -5,6 +5,14 @@
 		<meta name="viewport" content="width=device-width" />
 
 		<link rel="icon" type="image/svg+xml" href="%sveltekit.assets%/favicon.svg" />
+
+		<link rel="preconnect" href="https://fonts.googleapis.com" />
+		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
+		<link
+			href="https://fonts.googleapis.com/css2?family=Spectral:ital,wght@0,400;0,500;0,600;1,400&family=Work+Sans:wght@400;500;600&display=swap"
+			rel="stylesheet"
+		/>
+
 		%sveltekit.head%
 	</head>
 

--- a/apps/www/src/lib/app.css
+++ b/apps/www/src/lib/app.css
@@ -1,9 +1,185 @@
 @import '@tabitha/ui/theme.css';
 
+@theme {
+	--font-serif: 'Spectral', Georgia, 'Times New Roman', serif;
+	--font-sans: 'Work Sans', -apple-system, 'Segoe UI', sans-serif;
+}
+
+:root {
+	--paper: #f5efe2;
+	--paper-raised: #efe4d0;
+	--ink: #2b2420;
+	--ink-soft: #6b6153;
+	--terracotta: #b1512f;
+	--terracotta-soft: #e7c9b8;
+	--teal: #2c6a63;
+	--teal-soft: #cfe0dc;
+	--rule: #d8cbb3;
+}
+
 h1, h2, h3, h4, .text-balance {
 	text-wrap: balance;
 }
 
 p, article {
 	text-wrap: pretty;
+}
+
+body {
+	background: var(--paper);
+	color: var(--ink);
+	font-family: var(--font-sans);
+	line-height: 1.6;
+}
+
+h1, h2, h3 {
+	font-family: var(--font-serif);
+	font-weight: 500;
+	margin: 0 0 1rem;
+}
+
+h1 {
+	font-size: clamp(2.4rem, 5vw, 3.4rem);
+	line-height: 1.08;
+	margin-bottom: 1.1rem;
+	max-width: 14ch;
+}
+
+.site {
+	max-width: 920px;
+	margin: 0 auto;
+	padding: 0 1.5rem;
+}
+
+.site-header {
+	display: flex;
+	align-items: baseline;
+	justify-content: space-between;
+	padding: 3rem 0 1rem;
+	border-bottom: 1px solid var(--rule);
+}
+
+.wordmark {
+	font-family: var(--font-serif);
+	font-weight: 600;
+	font-size: 1.15rem;
+	letter-spacing: 0.02em;
+	color: var(--ink);
+	text-decoration: none;
+}
+
+.site-main {
+	padding: 3.5rem 0 5rem;
+}
+
+.site-footer {
+	padding: 2rem 0 3rem;
+	border-top: 1px solid var(--rule);
+	font-size: 0.85rem;
+	color: var(--ink-soft);
+}
+
+.footer-link {
+	color: var(--teal);
+	font-weight: 600;
+	text-decoration: none;
+}
+
+.footer-link:hover {
+	text-decoration: underline;
+}
+
+.hero-dek {
+	font-family: var(--font-serif);
+	font-style: italic;
+	font-weight: 400;
+	font-size: 1.35rem;
+	color: var(--ink-soft);
+	max-width: 34ch;
+	margin: 0 0 2.75rem;
+}
+
+.lede {
+	display: grid;
+	grid-template-columns: 3px 1fr;
+	gap: 1.5rem;
+	margin-bottom: 1.5rem;
+}
+
+.lede-rule {
+	background: var(--teal);
+	border-radius: 2px;
+}
+
+.lede p {
+	margin: 0 0 1.15rem;
+	max-width: 62ch;
+	font-size: 1.05rem;
+}
+
+.lede p:last-child {
+	margin-bottom: 0;
+}
+
+.lede strong {
+	color: var(--ink);
+	font-weight: 600;
+}
+
+.tools-link {
+	color: var(--teal);
+	font-weight: 600;
+	text-decoration: none;
+	border-bottom: 1px solid var(--teal-soft);
+}
+
+.tools-link:hover {
+	border-bottom-color: var(--teal);
+}
+
+.tiers-label {
+	font-size: 0.78rem;
+	text-transform: uppercase;
+	letter-spacing: 0.1em;
+	color: var(--ink-soft);
+	margin: 3rem 0 0.5rem;
+	padding-top: 2rem;
+	border-top: 1px solid var(--rule);
+}
+
+.tiers-note {
+	font-size: 0.85rem;
+	color: var(--ink-soft);
+	font-style: italic;
+	margin: 0 0 1.25rem;
+}
+
+.tiers {
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	gap: 1.5rem;
+}
+
+.tier {
+	border: 1px solid var(--rule);
+	padding: 1.4rem 1.4rem 1.6rem;
+	background: var(--paper-raised);
+}
+
+.tier h3 {
+	font-size: 1.15rem;
+	font-weight: 600;
+	margin: 0 0 0.5rem;
+}
+
+.tier p {
+	font-size: 0.92rem;
+	color: var(--ink-soft);
+	margin: 0;
+}
+
+@media (max-width: 640px) {
+	.tiers {
+		grid-template-columns: 1fr;
+	}
 }

--- a/apps/www/src/routes/+layout.svelte
+++ b/apps/www/src/routes/+layout.svelte
@@ -5,16 +5,18 @@
 	let { children }: { children?: Snippet } = $props()
 </script>
 
-<header class="mx-8 mt-8">
-	<a href="/" class="text-xl font-bold">TaBiThA</a>
-</header>
+<div class="site">
+	<header class="site-header">
+		<a href="/" class="wordmark">TaBiThA</a>
+	</header>
 
-<main class="mx-8 mt-8">
-	{#if children}
-		{@render children()}
-	{/if}
-</main>
+	<main class="site-main">
+		{#if children}
+			{@render children()}
+		{/if}
+	</main>
 
-<footer class="mx-8 mt-8 mb-8">
-	<a href="https://github.com/presciencelabs/tabitha" class="link link-hover">GitHub</a>
-</footer>
+	<footer class="site-footer">
+		<a href="https://github.com/presciencelabs/tabitha" class="footer-link">GitHub</a>
+	</footer>
+</div>

--- a/apps/www/src/routes/+page.svelte
+++ b/apps/www/src/routes/+page.svelte
@@ -1,4 +1,47 @@
-<h1 class="text-4xl font-bold">TaBiThA</h1>
-<p class="mt-4 max-w-prose">
-	This page is a placeholder -- content and design for the public site are still being scoped.
+<h1>Bible translation, generated with you in the room.</h1>
+<p class="hero-dek">
+	Software that turns decades of linguistic research into a working translation your team can
+	trust — then hands it back to you to make it sing.
 </p>
+
+<div class="lede">
+	<div class="lede-rule"></div>
+	<div>
+		<p>
+			Every language has its own grammar, its own way of marking who did what to whom, its own
+			sense of what goes without saying. TaBiThA was built by linguists to hold onto that — it
+			generates a working translation of Scripture text into your language using the same
+			features a trained translator would reach for, not a generic pass that flattens the nuance
+			out.
+		</p>
+		<p>
+			That means your team spends less time starting from a blank page, and more time doing the
+			part only you can do: <strong>checking it against how your language actually speaks</strong>,
+			refining it, making it clear, accurate, and natural.
+		</p>
+		<p>
+			It integrates seamlessly with many of the industry's leading Bible translation tools, found
+			at <a href="https://tools.bible" class="tools-link">tools.bible</a> — or stands on its own.
+		</p>
+	</div>
+</div>
+
+<div class="tiers-label">Go deeper</div>
+<p class="tiers-note">These sections are being built next.</p>
+<div class="tiers">
+	<div class="tier">
+		<h3>For translators</h3>
+		<p>
+			How the linguistic side works — the meta-language, the workflow, what a session with
+			TaBiThA actually looks like.
+		</p>
+	</div>
+	<div class="tier">
+		<h3>For developers</h3>
+		<p>The engineering side — architecture, APIs, and how to contribute to the project.</p>
+	</div>
+	<div class="tier">
+		<h3>The project</h3>
+		<p>Who's behind TaBiThA, what's left to build, and answers to common questions.</p>
+	</div>
+</div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -566,9 +566,6 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.3.3
         version: 4.3.3(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0))
-      '@vitest/coverage-v8':
-        specifier: ^3.2.7
-        version: 3.2.7(supports-color@10.2.2)(vitest@3.2.7(@types/debug@4.1.13)(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(supports-color@10.2.2)(terser@5.50.0))
       eslint:
         specifier: ^10.8.1
         version: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
@@ -584,9 +581,6 @@ importers:
       vite:
         specifier: 8.2.0
         version: 8.2.0(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)
-      vitest:
-        specifier: ^3.2.7
-        version: 3.2.7(@types/debug@4.1.13)(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(supports-color@10.2.2)(terser@5.50.0)
       wrangler:
         specifier: ^4.123.0
         version: 4.123.0(@cloudflare/workers-types@5.20260815.1)


### PR DESCRIPTION
## Summary
- Home page (Level 0 newcomer explainer) now has real content, replacing the placeholder shipped in PR #54
- Wired the agreed "warm-editorial" visual identity into `apps/www`: Spectral + Work Sans (Google Fonts), terracotta/teal palette, scoped to this app only
- Fixed `apps/www/package.json`: `test:unit`/`test:unit:watch`/`test:unit:coverage` had no test files and no `--passWithNoTests`, which was silently breaking root `pnpm test:unit` (and CI's `report_coverage.ts`) repo-wide. Dropped those + the unused vitest devDeps; left `test:e2e` alone since a real spec is landing in #56.

## Test plan
- [x] `pnpm check` (svelte-check + eslint) passes with 0 errors/warnings
- [x] `pnpm build` succeeds (prerendered output via adapter-cloudflare)
- [x] Verified visually with a Playwright screenshot of the running dev server, no console errors
- [x] Root `pnpm test:unit` now passes 25/25 (previously failed solely on `@tabitha/www`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)