### PR TITLE
perf(ci): dedupe eslint and parallelize typecheck/lint jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,14 +120,13 @@ jobs:
   # ============================================================================
   # STAGE 2: PARALLEL TEST & QUALITY MATRIX (Runs after Blockers Pass)
   # ============================================================================
-  code_quality:
-    name: 🔍 Code Quality & Typecheck
+  typecheck:
+    name: 🔍 Typecheck & Svelte Diagnostics
     needs: [plan, security_compliance, production_build]
     if: needs.plan.outputs.run_quality == 'true'
     runs-on: ubuntu-latest
     outputs:
       typecheck: ${{ steps.typecheck.outcome }}
-      eslint: ${{ steps.eslint.outcome }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -139,6 +138,20 @@ jobs:
         id: typecheck
         run: pnpm exec turbo run check ${{ needs.plan.outputs.turbo_filter }}
         continue-on-error: true
+
+  eslint:
+    name: 🔍 ESLint
+    needs: [plan, security_compliance, production_build]
+    if: needs.plan.outputs.run_quality == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      eslint: ${{ steps.eslint.outcome }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Workspace
+        uses: ./.github/actions/setup-workspace
 
       - name: ESLint
         id: eslint
@@ -273,7 +286,7 @@ jobs:
   pr_summary:
     name: 📝 Post PR Advisory Summary
     if: always() && github.event_name == 'pull_request'
-    needs: [plan, security_compliance, production_build, code_quality, unit_tests, e2e_tests]
+    needs: [plan, security_compliance, production_build, typecheck, eslint, unit_tests, e2e_tests]
     runs-on: ubuntu-latest
     # Org policy caps the default GITHUB_TOKEN at read-only, so this uses a fine-grained
     # PAT (repo-scoped to tabitha, Issues: write) stored as PR_SUMMARY_TOKEN instead.
@@ -303,8 +316,8 @@ jobs:
               ['README Badge & Version Sync', needs.security_compliance.outputs.badges],
               ['Philosophy Count Doc Sync', needs.security_compliance.outputs.philosophy_docs],
               ['Markdown Lint', needs.security_compliance.outputs.md],
-              ['Typecheck & Svelte Diagnostics', needs.code_quality.outputs.typecheck],
-              ['ESLint', needs.code_quality.outputs.eslint],
+              ['Typecheck & Svelte Diagnostics', needs.typecheck.outputs.typecheck],
+              ['ESLint', needs.eslint.outputs.eslint],
               ['Unit Test Coverage', needs.unit_tests.outputs.coverage],
               ['Playwright E2E', needs.e2e_tests.outputs.e2e],
             ]

--- a/apps/copilot/package.json
+++ b/apps/copilot/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "prepare": "svelte-kit sync",
-    "check": "pnpm prepare && (pnpm check:svelte & pnpm check:lint)",
+    "check": "pnpm prepare && pnpm check:svelte",
     "check:svelte": "svelte-check --tsconfig ./tsconfig.json",
     "check:lint": "eslint .",
     "check:lint:fix": "eslint . --fix",

--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "prepare": "svelte-kit sync",
-    "check": "pnpm prepare && (pnpm check:svelte & pnpm check:lint)",
+    "check": "pnpm prepare && pnpm check:svelte",
     "check:svelte": "svelte-check --tsconfig ./tsconfig.json",
     "check:lint": "eslint .",
     "check:lint:fix": "eslint . --fix",

--- a/apps/ontology/package.json
+++ b/apps/ontology/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "prepare": "svelte-kit sync",
-    "check": "pnpm prepare && (pnpm check:svelte & pnpm check:lint)",
+    "check": "pnpm prepare && pnpm check:svelte",
     "check:svelte": "svelte-check --tsconfig ./tsconfig.json",
     "check:lint": "eslint .",
     "check:lint:fix": "eslint . --fix",

--- a/apps/sources/package.json
+++ b/apps/sources/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "prepare": "svelte-kit sync",
-    "check": "pnpm prepare && (pnpm check:svelte & pnpm check:lint)",
+    "check": "pnpm prepare && pnpm check:svelte",
     "check:svelte": "svelte-check --tsconfig ./tsconfig.json",
     "check:lint": "eslint .",
     "check:lint:fix": "eslint . --fix",

--- a/apps/targets/package.json
+++ b/apps/targets/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "prepare": "svelte-kit sync",
-    "check": "pnpm prepare && (pnpm check:svelte & pnpm check:lint)",
+    "check": "pnpm prepare && pnpm check:svelte",
     "check:svelte": "svelte-check --tsconfig ./tsconfig.json",
     "check:lint": "eslint .",
     "check:lint:fix": "eslint . --fix",

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -5,7 +5,7 @@
 	"type": "module",
 	"scripts": {
 		"prepare": "svelte-kit sync",
-		"check": "pnpm prepare && (pnpm check:svelte & pnpm check:lint)",
+		"check": "pnpm prepare && pnpm check:svelte",
 		"check:svelte": "svelte-check --tsconfig ./tsconfig.json",
 		"check:lint": "eslint .",
 		"check:lint:fix": "eslint . --fix",


### PR DESCRIPTION
## Summary
- Each app's `check` script was backgrounding `check:lint` alongside `check:svelte`, so ESLint ran once inside the typecheck step and again in the dedicated ESLint step — a full redundant pass every CI run. Trimmed `check` down to `check:svelte` only.
- Split the `code_quality` job into two independent jobs (`typecheck`, `eslint`) that both depend only on `[plan, security_compliance, production_build]`, so GitHub Actions can run them concurrently instead of serially in one job.
- Updated `pr_summary`'s `needs` list and outcome lookups to reference the new job names.

## Test plan
- [x] `pnpm --filter @tabitha/editor check` runs `svelte-check` only (no backgrounded lint), 0 errors
- [x] Workflow YAML validated (`Ruby YAML.load_file`)
- [x] Confirmed `main`'s branch protection has no `required_status_checks` entries tied to the old `code_quality` job name, so the rename/split is safe
- [ ] CI on this PR passes with the new `typecheck` / `eslint` jobs running in parallel

🤖 Generated with [Claude Code](https://claude.com/claude-code)